### PR TITLE
renamed all dql to new names

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "files.exclude": {
-        "**/*.js.map": false,
-        "**/*.js": false,
+        "**/*.js.map": true,
+        "**/*.js": true,
         "**/*.d.ts": false,
         "test/": false,
         "node_modules": true,

--- a/endpoints/app.ts
+++ b/endpoints/app.ts
@@ -1,6 +1,6 @@
-import { BodyDQLEndpoint } from "../src/body/BodyDQLEndpoint";
+import { DQLEndpoint } from "../src/DQLEndpoint";
 
-const endpoint: BodyDQLEndpoint =  {
+const endpoint: DQLEndpoint =  {
     body: {
         name: {
             type: 'string',

--- a/endpoints/home.ts
+++ b/endpoints/home.ts
@@ -1,6 +1,6 @@
-import { BodyDQLEndpoint } from '../src/body/BodyDQLEndpoint';
+import { DQLEndpoint } from '../src/DQLEndpoint';
 
-const endpoint: BodyDQLEndpoint = {
+const endpoint: DQLEndpoint = {
     body : {
         name: {
             type: 'string',

--- a/endpoints/people.ts
+++ b/endpoints/people.ts
@@ -1,6 +1,6 @@
-import { BodyDQLEndpoint } from '../src/body/BodyDQLEndpoint';
+import { DQLEndpoint } from '../src/DQLEndpoint';
 
-const rootEndpoint: BodyDQLEndpoint = {
+const rootEndpoint: DQLEndpoint = {
     body: {
         name: {
             type: 'string',

--- a/endpoints/root.ts
+++ b/endpoints/root.ts
@@ -1,6 +1,6 @@
-import { BodyDQLEndpoint } from '../src/body/BodyDQLEndpoint';
+import { DQLEndpoint } from '../src/DQLEndpoint';
 
-const endpoint: BodyDQLEndpoint = {
+const endpoint: DQLEndpoint = {
     body : {
 
     },

--- a/server.ts
+++ b/server.ts
@@ -2,9 +2,9 @@ import home from './endpoints/home'
 import app from './endpoints/app'
 import root from './endpoints/root'
 import people from './endpoints/people'
-import DQL from './src/DQL'
+import DQLServer from './src/DQLServer'
 
-const server = new DQL()
+const server = new DQLServer()
 
 server.add(home.path , home.endpoint)
 server.add(app.path , app.endpoint)

--- a/src/DQLEndpoint.ts
+++ b/src/DQLEndpoint.ts
@@ -1,18 +1,20 @@
-import { BodyDQLEndpointProperty } from './BodyDQLEndpointProperty';
+import { DQLEndpointProperty } from './DQLEndpointProperty';
 import { Request , Response } from 'express'
 
-export type BodyDQLEndpoint = {
+export interface DQLEndpoint {
     
     /**
      *
      *
-     * @type {{ [id: string]: BodyDQLEndpointProperty; }}
+     * @type {{ [id: string]: DQLEndpointProperty; }}
      */
-    body: { [id: string]: BodyDQLEndpointProperty; };
+    body: { [id: string]: DQLEndpointProperty; };
 
     method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
 
     header?: { [id: string]: string; };
 
     middleware?: (request: Request , response: Response , next: () => void ) => void
+
+
 };

--- a/src/DQLEndpointManager.ts
+++ b/src/DQLEndpointManager.ts
@@ -1,28 +1,28 @@
 import isboolean from 'lodash.isboolean'
 import isnumber from 'lodash.isnumber'
 import isstring from 'lodash.isstring'
-import { BodyDQLEndpointProperty } from './BodyDQLEndpointProperty';
-import { BodyDQLEndpoint } from './BodyDQLEndpoint';
+import { DQLEndpointProperty } from './DQLEndpointProperty';
+import { DQLEndpoint } from './DQLEndpoint';
 
-export class BodyDQL {
+export class DQLEndpointManager {
 
     /**
      *
      *
-     * @type {{ [id: string]: BodyDQLEndpoint }}
+     * @type {{ [id: string]: DQLEndpoint }}
      * @memberof BodyDQL
      */
-    data: { [id: string]: BodyDQLEndpoint }
+    data: { [id: string]: DQLEndpoint }
 
     constructor() {
         this.data = {}
     }
 
-    add(name: string, endpoint: BodyDQLEndpoint) {
+    add(name: string, endpoint: DQLEndpoint) {
         this.data[name] = endpoint
     }
 
-    getEndpoints(): { path: string, endpoint: BodyDQLEndpoint }[] {
+    getEndpoints(): { path: string, endpoint: DQLEndpoint }[] {
         return Object.keys(this.data).map(key => {
             return {
                 path: key,
@@ -59,10 +59,10 @@ export class BodyDQL {
      *
      *
      * @param {string} key
-     * @returns {BodyDQLEndpoint}
+     * @returns {DQLEndpoint}
      * @memberof BodyDQL
      */
-    getEndpoint(key: string): BodyDQLEndpoint {
+    getEndpoint(key: string): DQLEndpoint {
         if (this.data[key] === undefined) {
             throw new Error(`endpoint with key ${key} does not exist`)
         }
@@ -73,23 +73,23 @@ export class BodyDQL {
     /**
      *
      *
-     * @param {BodyDQLEndpoint} endpoint
+     * @param {DQLEndpoint} endpoint
      * @returns {BodyDQLEndpointProperty[]}
      * @memberof BodyDQL
      */
-    getEndpointProperties(endpoint: BodyDQLEndpoint): BodyDQLEndpointProperty[] {
+    getEndpointProperties(endpoint: DQLEndpoint): DQLEndpointProperty[] {
         return Object.keys(endpoint.body).map(k => { return endpoint.body[k] })
     }
 
     /**
      *
      *
-     * @param {BodyDQLEndpoint} endPoint
+     * @param {DQLEndpoint} endPoint
      * @param {string} propname
      * @returns {BodyDQLEndpointProperty}
      * @memberof BodyDQL
      */
-    getEndpointProperty(endPoint: BodyDQLEndpoint, propname: string): BodyDQLEndpointProperty {
+    getEndpointProperty(endPoint: DQLEndpoint, propname: string): DQLEndpointProperty {
 
         if (endPoint.body[propname] === undefined) {
             throw new Error(`endpoint property with key ${propname} does not exist`)
@@ -187,7 +187,7 @@ export class BodyDQL {
      * @returns {Error[]}
      * @memberof BodyDQL
      */
-    validateProperty(data: { property: BodyDQLEndpointProperty, value: any | undefined | null }): Error[] {
+    validateProperty(data: { property: DQLEndpointProperty, value: any | undefined | null }): Error[] {
 
         const { property, value } = data
 
@@ -233,7 +233,7 @@ export class BodyDQL {
      * @returns {Error[]}
      * @memberof BodyDQL
      */
-    validateEndpointTypesMatch(property: BodyDQLEndpointProperty, value: any): Error[] {
+    validateEndpointTypesMatch(property: DQLEndpointProperty, value: any): Error[] {
         let errors: Error[] = []
        
         const parse = property.parse === undefined ? (i: any) => { return i } : property.parse! 
@@ -301,7 +301,7 @@ export class BodyDQL {
      * @returns {boolean}
      * @memberof BodyDQL
      */
-    isPropertyRequired(property: BodyDQLEndpointProperty): boolean {
+    isPropertyRequired(property: DQLEndpointProperty): boolean {
         return property.required === undefined ? false : property.required!
     }
 
@@ -314,7 +314,7 @@ export class BodyDQL {
      * @returns {boolean}
      * @memberof BodyDQL
      */
-    shouldValidateProperty(property: BodyDQLEndpointProperty, value: any | undefined | null): boolean {
+    shouldValidateProperty(property: DQLEndpointProperty, value: any | undefined | null): boolean {
         // let errors: Error[] = []
         switch (this.hasValue(value)) {
             case true: return true
@@ -334,7 +334,7 @@ export class BodyDQL {
      * @returns {Error[]}
      * @memberof BodyDQL
      */
-    getErrorsForProperty(propertyKey: string, prop: BodyDQLEndpointProperty): Error[] {
+    getErrorsForProperty(propertyKey: string, prop: DQLEndpointProperty): Error[] {
         if (prop.errors !== undefined && prop.errors[propertyKey] !== undefined) {
             return prop.errors[propertyKey].map(error => { return new Error(error) })
         }

--- a/src/DQLEndpointProperty.ts
+++ b/src/DQLEndpointProperty.ts
@@ -1,4 +1,4 @@
-export type BodyDQLEndpointProperty = {
+export interface DQLEndpointProperty {
     
     /**
      * The name of the property

--- a/src/DQLServer.ts
+++ b/src/DQLServer.ts
@@ -1,12 +1,12 @@
 
 
-import { BodyDQLEndpoint } from '../src/body/BodyDQLEndpoint'
+import { DQLEndpoint } from './DQLEndpoint'
 import e, { Response, Request } from 'express'
-import { BodyDQL } from './body/BodyDQL';
+import { DQLEndpointManager } from './DQLEndpointManager';
 import bodyParser = require('body-parser');
 
 
-export class DQL {
+export class DQLServer {
 
     server: e.Express
 
@@ -14,10 +14,10 @@ export class DQL {
 
     host?: string
  
-    endpoints: BodyDQL
+    endpoints: DQLEndpointManager
 
     constructor() {
-        this.endpoints = new BodyDQL()
+        this.endpoints = new DQLEndpointManager()
         this.server = e()
         this.server.use(this.handleNotFound.bind(this))
         this.server.use(this.handleMethodNotAllowed.bind(this))
@@ -68,7 +68,7 @@ export class DQL {
      */
     handleMethodNotAllowed(request: Request , response: Response , next: () => void) {
         
-        const isMethodAllowed = (request: Request , endpoint: BodyDQLEndpoint) => {
+        const isMethodAllowed = (request: Request , endpoint: DQLEndpoint) => {
             return endpoint.method !== undefined && endpoint.method! === request.method
         }
 
@@ -103,7 +103,7 @@ export class DQL {
         }
     }
 
-    add(name: string, endpoint: BodyDQLEndpoint): DQL {
+    add(name: string, endpoint: DQLEndpoint): DQLServer {
         this.endpoints.add(name, endpoint)
         return this  
     } 
@@ -194,5 +194,5 @@ export class DQL {
 }
 
 
-export default DQL
+export default DQLServer
 

--- a/test/body/DQLEndpointManager.getErrorsForProperty.test.ts
+++ b/test/body/DQLEndpointManager.getErrorsForProperty.test.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../node_modules/mocha-typescript/globals.d.ts'/>
-import { BodyDQL } from "../../src/body/BodyDQL";
+import { DQLEndpointManager } from "../../src/DQLEndpointManager";
 import { expect } from 'chai'
 
-@suite('BodyDQLUnitTest - getErrorsForProperty')
-export class BodyDQLUnitTest extends BodyDQL {
+@suite('DQLEndpointManager - getErrorsForProperty')
+export class DQLEndpointManagerUnitTest extends DQLEndpointManager {
 
    @test "returns array of errors for property name when errors property exists" () {
     this.data = {

--- a/test/body/DQLEndpointManager.hasValue.test.ts
+++ b/test/body/DQLEndpointManager.hasValue.test.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../node_modules/mocha-typescript/globals.d.ts'/>
-import { BodyDQL } from "../../src/body/BodyDQL";
+import { DQLEndpointManager } from "../../src/DQLEndpointManager";
 import { expect } from 'chai'
 
-@suite('BodyDQLUnitTest - hasValue')
-export class BodyDQLUnitTest extends BodyDQL {
+@suite('DQLEndpointManager - hasValue')
+export class DQLEndpointManagerUnitTest extends DQLEndpointManager {
 
     @test "validates has Value return true and false for all various values" () {
        expect(this.hasValue(1)).true

--- a/test/body/DQLEndpointManager.isPropertyRequired.test.ts
+++ b/test/body/DQLEndpointManager.isPropertyRequired.test.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../node_modules/mocha-typescript/globals.d.ts'/>
-import { BodyDQL } from "../../src/body/BodyDQL";
+import { DQLEndpointManager } from "../../src/DQLEndpointManager";
 import { expect } from 'chai'
 
-@suite('BodyDQLUnitTest - isPropertyRequired')
-export class BodyDQLUnitTest extends BodyDQL {
+@suite('DQLEndpointManager - isPropertyRequired')
+export class DQLEndpointManagerUnitTest extends DQLEndpointManager {
 
     @test "validates if a property is required to be validated" () {
         this.data = {

--- a/test/body/DQLEndpointManager.shouldValidateProperty.test.ts
+++ b/test/body/DQLEndpointManager.shouldValidateProperty.test.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../node_modules/mocha-typescript/globals.d.ts'/>
-import { BodyDQL } from "../../src/body/BodyDQL";
+import { DQLEndpointManager } from "../../src/DQLEndpointManager";
 import { expect } from 'chai'
 
-@suite('BodyDQLUnitTest - shouldValidateProperty')
-export class BodyDQLUnitTest extends BodyDQL {
+@suite('DQLEndpointManager - shouldValidateProperty')
+export class DQLEndpointManagerUnitTest extends DQLEndpointManager {
 
     @test "validates if a property is required to be validated" () {
         this.data = {

--- a/test/body/DQLEndpointManager.validate.ts
+++ b/test/body/DQLEndpointManager.validate.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../node_modules/mocha-typescript/globals.d.ts'/>
-import { BodyDQL } from "../../src/body/BodyDQL";
+import { DQLEndpointManager } from "../../src/DQLEndpointManager";
 import { expect } from 'chai'
 
-@suite('BodyDQLUnitTest - validate Request Body')
-export class BodyDQLUnitTest extends BodyDQL {
+@suite('DQLEndpointManager - validate Request Body')
+export class DQLEndpointManagerUnitTest extends DQLEndpointManager {
 
     @test "validate throws an error when name property does not exist and required is true"() {
 

--- a/test/body/DQLEndpointManager.validateEndpointTypesMatch.test.ts
+++ b/test/body/DQLEndpointManager.validateEndpointTypesMatch.test.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../node_modules/mocha-typescript/globals.d.ts'/>
-import { BodyDQL } from "../../src/body/BodyDQL";
+import { DQLEndpointManager } from "../../src/DQLEndpointManager";
 import { expect } from 'chai'
 
-@suite('BodyDQLUnitTest - validateEndpointTypesMatch')
-export class BodyDQLUnitTest extends BodyDQL {
+@suite('DQLEndpointManager - validateEndpointTypesMatch')
+export class DQLEndpointManagerUnitTest extends DQLEndpointManager {
 
     @test "returns custom array of errors for property isOld when the type of the value does not match the types specification"() {
         this.data = {

--- a/test/body/DQLEndpointManager.validateProperty.test.ts
+++ b/test/body/DQLEndpointManager.validateProperty.test.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../node_modules/mocha-typescript/globals.d.ts'/>
-import { BodyDQL } from "../../src/body/BodyDQL";
+import { DQLEndpointManager } from "../../src/DQLEndpointManager";
 import { expect } from 'chai'
 
-@suite('BodyDQLUnitTest - validateProperty')
-export class BodyDQLUnitTest extends BodyDQL {
+@suite('DQLEndpointManager - validateProperty')
+export class DQLEndpointManagerUnitTest extends DQLEndpointManager {
 
     @test "returns the correct number of errors message when invalid data provided"() {
 

--- a/test/body/DQLEndpointManager.validatedEndpoints.test.ts
+++ b/test/body/DQLEndpointManager.validatedEndpoints.test.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../node_modules/mocha-typescript/globals.d.ts'/>
-import { BodyDQL } from "../../src/body/BodyDQL";
+import { DQLEndpointManager } from "../../src/DQLEndpointManager";
 import { expect } from 'chai'
 
-@suite('BodyDQLUnitTest - validatedEndpoints')
-export class BodyDQLUnitTest extends BodyDQL {
+@suite('DQLEndpointManager - validatedEndpoints')
+export class DQLEndpointManagerUnitTest extends DQLEndpointManager {
 
     goodMockdata: { [id: string] : any } = {
         "/app" : {

--- a/test/body/index.test.ts
+++ b/test/body/index.test.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../node_modules/mocha-typescript/globals.d.ts'/>
-import { BodyDQL } from "../../src/body/BodyDQL";
+import { DQLEndpointManager } from "../../src/DQLEndpointManager";
 import { expect } from 'chai'
 
-@suite('BodyDQLUnitTest')
-export class BodyDQLUnitTest extends BodyDQL {
+@suite('DQLEndpointManager')
+export class DQLEndpointManagerUnitTest extends DQLEndpointManager {
 
     @test "loadFile returns an object" () {
         const data = this.loadFile()

--- a/test/endpoints/home.test.ts
+++ b/test/endpoints/home.test.ts
@@ -6,7 +6,7 @@ import chai,{expect} from 'chai'
 chai.use(require('chai-http'));
 
 @suite('Home Endpoint')
-export class T {
+export class HomeEndpointUnitTest {
 
     host: string = 'localhost:3000'
 
@@ -33,7 +33,7 @@ export class T {
             name: 1
         })
         .end((error, res) => {
-            expect(res.status).to.be.equal(200)
+            expect(res.status).to.be.equal(400)
         })
 
     }

--- a/test/server/server.test.ts
+++ b/test/server/server.test.ts
@@ -6,7 +6,7 @@ import chai,{expect} from 'chai'
 chai.use(require('chai-http'));
 
 @suite('DQL Server ')
-export class T {
+export class DQLServerUnitTest {
 
     host: string = 'localhost:3000'
 


### PR DESCRIPTION
I renamed the DQL classes to be DQLServer, DQLEndpoint, DQLEndpointProperty and DQLEndpointManager. All DQLEndpoints are now interfaces rather than types.